### PR TITLE
fix:fix the render of "No examples provided."

### DIFF
--- a/src/webviews/problemDetailPanel.ts
+++ b/src/webviews/problemDetailPanel.ts
@@ -214,7 +214,7 @@ export class ProblemDetailPanel extends BasePanel {
 
             <div class="section">
                 <h2>Examples</h2>
-                ${examplesHtml || '*No examples provided.*'}
+                ${examplesHtml || md.render('*No examples provided.*')}
             </div>
 
             <div class="section">


### PR DESCRIPTION
The extension will fail to render "No examples provided." correctly.  Use `md.render()` may solve the problem.